### PR TITLE
Do not ignore --aws-profile command-line argument

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,7 +51,7 @@ def handler(event, context):
 
 
 def cloudwatch_event_dispatcher(event, args):
-    if "AWS_PROFILE" in os.environ:
+    if args.aws_profile is not "default":
         boto3.setup_default_session(
             profile_name=args.aws_profile, region_name=args.aws_region
         )


### PR DESCRIPTION
This PR fixes the bug where if AWS profile is supplied on command-line, it is ignored.

`args.aws_profile` always has a value as below, higher precedence first:
- value of `AWS_PROFILE` environment variable
- value of `--aws-profile` argument supplied on command-line
- `default` if both above are unset

